### PR TITLE
Allow passing custom helper set in configuration

### DIFF
--- a/.docs/README.md
+++ b/.docs/README.md
@@ -27,6 +27,7 @@ console:
     catchExceptions: true / false
     autoExit: true / false
     url: https://contributte.com
+    helperSet: @customHelperSet
 ```
 
 In fact in console mode / SAPI mode is no http request and thus no URL address. It is inconvenience you have to solve by yoursolve.

--- a/src/DI/ConsoleExtension.php
+++ b/src/DI/ConsoleExtension.php
@@ -22,6 +22,7 @@ class ConsoleExtension extends CompilerExtension
 		'version' => NULL,
 		'catchExceptions' => NULL,
 		'autoExit' => NULL,
+		'helperSet' => NULL,
 	];
 
 	/**
@@ -54,6 +55,10 @@ class ConsoleExtension extends CompilerExtension
 
 		if ($config['autoExit'] !== NULL) {
 			$application->addSetup('autoExit', [(bool) $config['autoExit']]);
+		}
+
+		if ($config['helperSet'] !== NULL) {
+			$application->addSetup('setHelperSet', [$config['helperSet']]);
 		}
 	}
 


### PR DESCRIPTION
Use case is for example registering Doctrine commands which require additional helpers to work.

I wanted to find more elegant solution but for now this is the best I found. I cannot set the helper set to individual command when it is created, because it is overwritten when the command is added to the application.