### PR TITLE
Allow Console registration in not CLI mode

### DIFF
--- a/src/DI/ConsoleExtension.php
+++ b/src/DI/ConsoleExtension.php
@@ -125,7 +125,7 @@ class ConsoleExtension extends CompilerExtension
 		$application = $builder->getDefinition($this->prefix('application'));
 
 		// Setup URL in CLI
-		if(PHP_SAPI === 'cli') {
+		if (PHP_SAPI === 'cli') {
             if ($builder->hasDefinition('http.request') && $config['url'] !== NULL) {
                 $builder->getDefinition('http.request')
                     ->setClass(Request::class, [new Statement(UrlScript::class, [$config['url']])]);


### PR DESCRIPTION
Console is useful in not CLI for running commands through ArrayInput. Without Console\Application is impossible to do proper deployment to servers, where is CLI access not available. https://github.com/modette/http-maintenance#usage---with-nette-framework-symfony-console-and-dgftp-deployment