### PR TITLE
Register console commands also in non-sapi mode

### DIFF
--- a/.docs/README.md
+++ b/.docs/README.md
@@ -11,8 +11,7 @@
 
 ```yaml
 extensions:
-    console: Contributte\Console\DI\ConsoleExtension
-    
+    console: Contributte\Console\DI\ConsoleExtension(%consoleMode%) 
 ```
 
 The extension will look for all commands extending from [`Symfony\Component\Console\Command\Command`](https://github.com/symfony/symfony/blob/master/src/Symfony/Component/Console/Command/Command.php) and automatically add them to the console application. 
@@ -33,7 +32,7 @@ console:
       - Contributte\Console\Helper\ContainerHelper
 ```
 
-In fact in console mode / SAPI mode is no http request and thus no URL address. This inconvenience you have to solve by yoursolve.
+In fact in SAPI (CLI) mode there is no http request and thus no URL address. This inconvenience you have to solve by yourselve. Well, via `console.url` option.
  
 ```yaml
 console:
@@ -88,7 +87,7 @@ How to define command names? Define `$defaultName` in command or via `console.co
 ```php
 class FooCommand extends Command
 {
-    public static $defaultName = 'app:foo';
+    protected static $defaultName = 'app:foo';
 }
 ```
 

--- a/src/CommandLoader/ContainerCommandLoader.php
+++ b/src/CommandLoader/ContainerCommandLoader.php
@@ -2,9 +2,9 @@
 
 namespace Contributte\Console\CommandLoader;
 
+use Contributte\Console\Exception\Runtime\CommandNotFoundException;
 use Nette\DI\Container;
 use Symfony\Component\Console\CommandLoader\CommandLoaderInterface;
-use Symfony\Component\Console\Exception\CommandNotFoundException;
 
 class ContainerCommandLoader implements CommandLoaderInterface
 {

--- a/src/Exception/Logical/InvalidArgumentException.php
+++ b/src/Exception/Logical/InvalidArgumentException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Contributte\Console\Exception\Logical;
+
+use Contributte\Console\Exception\LogicalException;
+
+class InvalidArgumentException extends LogicalException
+{
+
+}

--- a/src/Exception/LogicalException.php
+++ b/src/Exception/LogicalException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Contributte\Console\Exception;
+
+use LogicException;
+
+class LogicalException extends LogicException
+{
+
+}

--- a/src/Exception/Runtime/CommandNotFoundException.php
+++ b/src/Exception/Runtime/CommandNotFoundException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Contributte\Console\Exception\Runtime;
+
+use Contributte\Console\Exception\RuntimeException;
+
+class CommandNotFoundException extends RuntimeException
+{
+
+}

--- a/src/Exception/RuntimeException.php
+++ b/src/Exception/RuntimeException.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Contributte\Console\Exception;
+
+class RuntimeException extends \RuntimeException
+{
+
+}

--- a/tests/cases/Command/Command.HelperSet.phpt
+++ b/tests/cases/Command/Command.HelperSet.phpt
@@ -20,14 +20,14 @@ require_once __DIR__ . '/../../bootstrap.php';
 test(function () {
 	$loader = new ContainerLoader(TEMP_DIR, TRUE);
 	$class = $loader->load(function (Compiler $compiler) {
-		$compiler->addExtension('console', new ConsoleExtension());
+		$compiler->addExtension('console', new ConsoleExtension(TRUE));
 		$compiler->loadConfig(FileMock::create('
 		console:
 			lazy: off
 		services:
 			- Tests\Fixtures\HelperSetCommand
 		', 'neon'));
-	}, [microtime(), 2]);
+	}, [getmypid(), 1]);
 
 	/** @var Container $container */
 	$container = new $class;

--- a/tests/cases/CommandLoader/CommandLoader.phpt
+++ b/tests/cases/CommandLoader/CommandLoader.phpt
@@ -1,0 +1,27 @@
+<?php
+
+/**
+ * Test: CommandLoader/CommandLoader
+ */
+
+use Contributte\Console\CommandLoader\ContainerCommandLoader;
+use Contributte\Console\Exception\Runtime\CommandNotFoundException;
+use Nette\DI\Container;
+use Tester\Assert;
+use Tester\Environment;
+
+require_once __DIR__ . '/../../bootstrap.php';
+
+if (!interface_exists('Symfony\Component\Console\CommandLoader\CommandLoaderInterface', TRUE)) {
+	Environment::skip('CommandLoaderInterface is available from symfony/console 3.4');
+}
+
+// Empty loader
+test(function () {
+	$container = new Container();
+	$loader = new ContainerCommandLoader($container, []);
+
+	Assert::exception(function () use ($loader) {
+		$loader->get('foo');
+	}, CommandNotFoundException::class, 'Command "foo" does not exist.');
+});

--- a/tests/cases/DI/ConsoleExtension.HelperSet.phpt
+++ b/tests/cases/DI/ConsoleExtension.HelperSet.phpt
@@ -18,8 +18,8 @@ require_once __DIR__ . '/../../bootstrap.php';
 test(function () {
 	$loader = new ContainerLoader(TEMP_DIR, TRUE);
 	$class = $loader->load(function (Compiler $compiler) {
-		$compiler->addExtension('console', new ConsoleExtension());
-	}, [microtime(), 1]);
+		$compiler->addExtension('console', new ConsoleExtension(TRUE));
+	}, [getmypid(), 1]);
 
 	/** @var Container $container */
 	$container = new $class;
@@ -33,12 +33,12 @@ test(function () {
 test(function () {
 	$loader = new ContainerLoader(TEMP_DIR, TRUE);
 	$class = $loader->load(function (Compiler $compiler) {
-		$compiler->addExtension('console', new ConsoleExtension());
+		$compiler->addExtension('console', new ConsoleExtension(TRUE));
 		$compiler->loadConfig(FileMock::create('
 		console:
 			helperSet: Tests\Fixtures\FooHelperSet
 		', 'neon'));
-	}, [microtime(), 3]);
+	}, [getmypid(), 2]);
 
 	/** @var Container $container */
 	$container = new $class;
@@ -51,7 +51,7 @@ test(function () {
 test(function () {
 	$loader = new ContainerLoader(TEMP_DIR, TRUE);
 	$class = $loader->load(function (Compiler $compiler) {
-		$compiler->addExtension('console', new ConsoleExtension());
+		$compiler->addExtension('console', new ConsoleExtension(TRUE));
 		$compiler->loadConfig(FileMock::create('
 		console:
 			helperSet: @Tests\Fixtures\FooHelperSet
@@ -59,7 +59,7 @@ test(function () {
 		services:
 			- Tests\Fixtures\FooHelperSet
 		', 'neon'));
-	}, [microtime(), 3]);
+	}, [getmypid(), 3]);
 
 	/** @var Container $container */
 	$container = new $class;
@@ -72,13 +72,13 @@ test(function () {
 test(function () {
 	$loader = new ContainerLoader(TEMP_DIR, TRUE);
 	$class = $loader->load(function (Compiler $compiler) {
-		$compiler->addExtension('console', new ConsoleExtension());
+		$compiler->addExtension('console', new ConsoleExtension(TRUE));
 		$compiler->loadConfig(FileMock::create('
 		console:
 			helpers:
 				- Tests\Fixtures\FooHelper
 		', 'neon'));
-	}, [microtime(), 4]);
+	}, [getmypid(), 4]);
 
 	/** @var Container $container */
 	$container = new $class;

--- a/tests/cases/DI/ConsoleExtension.lazy.phpt
+++ b/tests/cases/DI/ConsoleExtension.lazy.phpt
@@ -17,22 +17,22 @@ use Tests\Fixtures\FooCommand;
 
 require_once __DIR__ . '/../../bootstrap.php';
 
-if (!class_exists('Symfony\Component\Console\CommandLoader\CommandLoaderInterface')) {
-	Environment::skip('symfony/console 4.x is required');
+if (!interface_exists('Symfony\Component\Console\CommandLoader\CommandLoaderInterface', TRUE)) {
+	Environment::skip('CommandLoaderInterface is available from symfony/console 3.4');
 }
 
 // 1 command of type FooCommand lazy-loading
 test(function () {
 	$loader = new ContainerLoader(TEMP_DIR, TRUE);
 	$class = $loader->load(function (Compiler $compiler) {
-		$compiler->addExtension('console', new ConsoleExtension());
+		$compiler->addExtension('console', new ConsoleExtension(TRUE));
 		$compiler->loadConfig(FileMock::create('
 		console:
 			lazy: on
 		services:
 			foo: Tests\Fixtures\FooCommand
 		', 'neon'));
-	}, [microtime(), 3]);
+	}, [getmypid(), 1]);
 
 	/** @var Container $container */
 	$container = new $class;

--- a/tests/cases/DI/ConsoleExtension.phpt
+++ b/tests/cases/DI/ConsoleExtension.phpt
@@ -6,6 +6,8 @@
 
 use Contributte\Console\Application;
 use Contributte\Console\DI\ConsoleExtension;
+use Contributte\Console\Exception\Logical\InvalidArgumentException;
+use Nette\Bridges\HttpDI\HttpExtension;
 use Nette\DI\Compiler;
 use Nette\DI\Container;
 use Nette\DI\ContainerLoader;
@@ -20,8 +22,8 @@ require_once __DIR__ . '/../../bootstrap.php';
 test(function () {
 	$loader = new ContainerLoader(TEMP_DIR, TRUE);
 	$class = $loader->load(function (Compiler $compiler) {
-		$compiler->addExtension('console', new ConsoleExtension());
-	}, [microtime(), 1]);
+		$compiler->addExtension('console', new ConsoleExtension(TRUE));
+	}, [getmypid(), 1]);
 
 	/** @var Container $container */
 	$container = new $class;
@@ -33,14 +35,14 @@ test(function () {
 test(function () {
 	$loader = new ContainerLoader(TEMP_DIR, TRUE);
 	$class = $loader->load(function (Compiler $compiler) {
-		$compiler->addExtension('console', new ConsoleExtension());
+		$compiler->addExtension('console', new ConsoleExtension(TRUE));
 		$compiler->loadConfig(FileMock::create('
 		console:
 			lazy: off
 		services:
 			foo: Tests\Fixtures\FooCommand
 		', 'neon'));
-	}, [microtime(), 2]);
+	}, [getmypid(), 2]);
 
 	/** @var Container $container */
 	$container = new $class;
@@ -49,4 +51,29 @@ test(function () {
 	Assert::true($container->isCreated('foo'));
 	Assert::count(1, $container->findByType(Command::class));
 	Assert::type(FooCommand::class, $container->getByType(Command::class));
+});
+
+// Provide URL
+test(function () {
+	$loader = new ContainerLoader(TEMP_DIR, TRUE);
+	$class = $loader->load(function (Compiler $compiler) {
+		$compiler->addExtension('console', new ConsoleExtension(TRUE));
+		$compiler->addExtension('http', new HttpExtension(TRUE));
+		$compiler->loadConfig(FileMock::create('
+		console:
+			url: https://contributte.org/
+		', 'neon'));
+	}, [getmypid(), 3]);
+
+	/** @var Container $container */
+	$container = new $class;
+
+	Assert::equal('https://contributte.org/', (string) $container->getService('http.request')->getUrl());
+});
+
+// No CLI mode
+test(function () {
+	Assert::exception(function () {
+		new ConsoleExtension();
+	}, InvalidArgumentException::class, 'Provide CLI mode, e.q. Contributte\Console\DI\ConsoleExtension(%consoleMode%).');
 });


### PR DESCRIPTION
I've changed default behaviour, because it prevents to pre-compile container with all console services.

It's similar as #12 PR, but with more friendly way. I hope so.

Could you please elaborate guys?

Does it solve your problems @mabar @paveljanda @pilec?