### PR TITLE
Feature: support for nette/di:v3.0.0-dev

### DIFF
--- a/src/DI/ConsoleExtension.php
+++ b/src/DI/ConsoleExtension.php
@@ -124,7 +124,7 @@ class ConsoleExtension extends CompilerExtension
 		// Setup URL for CLI
 		if ($builder->hasDefinition('http.request') && $config['url'] !== null) {
 			$builder->getDefinition('http.request')
-				->setClass(Request::class, [new Statement(UrlScript::class, [$config['url']])]);
+				->setFactory(Request::class, [new Statement(UrlScript::class, [$config['url']])]);
 		}
 
 		// Register all commands (if they are not lazy-loaded)


### PR DESCRIPTION
This one is not a BC, but has been a blocker for v3-dev.

https://github.com/nette/di/blob/master/src/DI/ServiceDefinition.php#L70

Do you plan to support nette v3-dev packages, or you are waiting for official release?
Should I send more PRs (to other packages) with support for nette/di:v3-dev?