### PR TITLE
Next: New version with Nette v3

### DIFF
--- a/.docs/README.md
+++ b/.docs/README.md
@@ -145,16 +145,27 @@ You can copy & paste it to your project, for example to `<root>/bin/console`.
 
 Make sure to set it as executable. `chmod +x <root>/bin/console`.
 
+##### Nette 3.0+
+
 ```php
 #!/usr/bin/env php
-<?php
+<?php declare(strict_types=1);
 
-/** @var Nette\DI\Container $container */
+require __DIR__ . '/../vendor/autoload.php';
+
+exit(App\Bootstrap::boot()
+    ->createContainer()
+    ->getByType(Contributte\Console\Application::class)
+    ->run());
+```
+
+##### Nette <= 2.4
+
+```php
+#!/usr/bin/env php
+<?php declare(strict_types=1);
+
 $container = require __DIR__ . '/../app/bootstrap.php';
 
-// Get application from DI container.
-$application = $container->getByType(Contributte\Console\Application::class);
-
-// Run application.
-exit($application->run());
+exit($container->getByType(Contributte\Console\Application::class)->run());
 ```

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,62 +1,55 @@
 language: php
 php:
-  - 7.1
   - 7.2
   - 7.3
+  - 7.4snapshot
+  - nightly
 
 before_install:
-  # Turn off XDebug
-  - phpenv config-rm xdebug.ini || return 0
+  - phpenv config-rm xdebug.ini || return 0 # Turn off XDebug
 
 install:
-  # Composer
-  - travis_retry composer install --no-progress --prefer-dist
+  - travis_retry composer install --no-progress --prefer-dist # Install dependencies
 
 script:
-  # Tests
-  - composer run-script tests
+  - make tests # Tests
 
 after_failure:
-  # Print *.actual content
-  - for i in $(find tests -name \*.actual); do echo "--- $i"; cat $i; echo; echo; done
+  - for i in $(find tests -name \*.actual); do echo "--- $i"; cat $i; echo; echo; done # Print *.actual content
 
 jobs:
   include:
-    - env: title="Lowest Dependencies 7.1"
-      php: 7.1
+    - env: title="Lowest Dependencies 7.2"
+      php: 7.2
       install:
-        - travis_retry composer update --no-progress --prefer-dist --prefer-lowest
+        - travis_retry composer update --no-progress --prefer-dist --prefer-lowest --prefer-stable
       script:
-        - composer run-script tests
+        - make tests
 
     - stage: Quality Assurance
-      php: 7.1
+      php: 7.3
       script:
-        - composer run-script qa
-
-    - stage: Phpstan
-      php: 7.1
-      script:
-        - composer run-script phpstan-install
-        - composer run-script phpstan
+        - make qa
 
     - stage: Test Coverage
       if: branch = master AND type = push
-      php: 7.1
+      php: 7.3
       script:
-        - composer run-script coverage
+        - make coverage
       after_script:
-        - wget https://github.com/php-coveralls/php-coveralls/releases/download/v2.1.0/php-coveralls.phar
-        - php php-coveralls.phar --verbose --config tests/.coveralls.yml
+        - composer global require php-coveralls/php-coveralls ^2.1.0
+        - ~/.composer/vendor/bin/php-coveralls --verbose --config tests/.coveralls.yml
 
     - stage: Outdated Dependencies
       if: branch = master AND type = cron
-      php: 7.1
+      php: 7.3
       script:
-        - composer outdated --direct --strict
+        - composer outdated --direct
 
   allow_failures:
     - stage: Test Coverage
+    - php: 7.4snapshot
+    - php: nightly
 
 sudo: false
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,27 @@
+.PHONY: qa lint cs csf phpstan tests coverage
+
+all:
+	@$(MAKE) -pRrq -f $(lastword $(MAKEFILE_LIST)) : 2>/dev/null | awk -v RS= -F: '/^# File/,/^# Finished Make data base/ {if ($$1 !~ "^[#.]") {print $$1}}' | sort | egrep -v -e '^[^[:alnum:]]' -e '^$@$$' | xargs
+
+vendor: composer.json composer.lock
+	composer install
+
+qa: lint phpstan cs
+
+lint: vendor
+	vendor/bin/linter src tests
+
+cs: vendor
+	vendor/bin/codesniffer src tests
+
+csf: vendor
+	vendor/bin/codefixer src tests
+
+phpstan: vendor
+	vendor/bin/phpstan analyse -l max -c phpstan.neon src
+
+tests: vendor
+	vendor/bin/tester -s -p php --colors 1 -C tests/cases
+
+coverage: vendor
+	vendor/bin/tester -s -p phpdbg --colors 1 -C --coverage ./coverage.xml --coverage-src ./src tests/cases

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Ultra easy-to-use [`Symfony\Console`](https://github.com/symfony/console) implem
 [![Downloads this Month](https://img.shields.io/packagist/dm/contributte/console.svg?style=flat-square)](https://packagist.org/packages/contributte/console)
 [![Downloads total](https://img.shields.io/packagist/dt/contributte/console.svg?style=flat-square)](https://packagist.org/packages/contributte/console)
 [![Latest stable](https://img.shields.io/packagist/v/contributte/console.svg?style=flat-square)](https://packagist.org/packages/contributte/console)
-[![PHPStan](https://img.shields.io/badge/PHPStan-enabled-brightgreen.svg?style=flat)](https://github.com/phpstan/phpstan)
+[![PHPStan](https://img.shields.io/badge/PHPStan-enabled-brightgreen.svg?style=flat-square)](https://github.com/phpstan/phpstan)
 
 ## Discussion / Help
 
@@ -24,11 +24,10 @@ composer require contributte/console
 
 ## Versions
 
-| State       | Version      | Branch   | PHP      |
-|-------------|--------------|----------|----------|
-| dev         | `^0.6.0`     | `master` | `>= 7.1` |
-| stable      | `^0.5.0`     | `master` | `>= 7.1` |
-| stable      | `^0.4.0`     | `master` | `>= 5.6` |
+| State       | Version      | Branch   | Nette  | PHP    |
+|-------------|--------------|----------|--------|--------|
+| development | `^0.7.0`     | `master` | `3.0+` | `^7.2` |
+| stable      | `^0.6.0`     | `master` | `2.4`  | `^7.1` |
 
 ## Overview
 

--- a/composer.json
+++ b/composer.json
@@ -16,23 +16,22 @@
     }
   ],
   "require": {
-    "php": ">= 7.1",
-    "symfony/console": "^4.0.0"
+    "php": "^7.2",
+    "symfony/console": "^4.2.9"
   },
   "require-dev": {
-    "ninjify/qa": "^0.8.0",
-    "ninjify/nunjuck": "^0.2.0",
-    "nette/di": "~2.4.11",
-    "nette/http": "~2.4.8"
+    "ninjify/qa": "^0.9.0",
+    "ninjify/nunjuck": "^0.3.0",
+    "nette/di": "~3.0.0",
+    "nette/http": "~3.0.1",
+    "phpstan/phpstan-shim": "^0.11.8",
+    "phpstan/phpstan-deprecation-rules": "^0.11.2",
+    "phpstan/phpstan-nette": "^0.11.1",
+    "phpstan/phpstan-strict-rules": "^0.11.1"
   },
   "suggest": {
     "nette/di": "to use ConsoleExtension[CompilerExtension]"
   },
-  "conflict": {
-    "nette/utils": "<2.5.2"
-  },
-  "minimum-stability": "dev",
-  "prefer-stable": true,
   "autoload": {
     "psr-4": {
       "Contributte\\Console\\": "src"
@@ -40,34 +39,18 @@
   },
   "autoload-dev": {
     "psr-4": {
+      "Tests\\Cases\\": "tests/cases",
       "Tests\\Fixtures\\": "tests/fixtures"
     }
   },
-  "scripts": {
-    "qa": [
-      "linter src tests",
-      "codesniffer src tests"
-    ],
-    "tests": [
-      "tester -s -p php --colors 1 -C tests/cases"
-    ],
-    "coverage": [
-      "tester -s -p phpdbg --colors 1 -C --coverage ./coverage.xml --coverage-src ./src tests/cases"
-    ],
-    "phpstan-install": [
-      "mkdir -p temp/phpstan",
-      "composer require -d temp/phpstan phpstan/phpstan:^0.10",
-      "composer require -d temp/phpstan phpstan/phpstan-deprecation-rules:^0.10",
-      "composer require -d temp/phpstan phpstan/phpstan-nette:^0.10",
-      "composer require -d temp/phpstan phpstan/phpstan-strict-rules:^0.10"
-    ],
-    "phpstan": [
-      "temp/phpstan/vendor/bin/phpstan analyse -l max -c phpstan.neon src"
-    ]
+  "minimum-stability": "dev",
+  "prefer-stable": true,
+  "config": {
+    "sort-packages": true
   },
   "extra": {
     "branch-alias": {
-      "dev-master": "0.6.x-dev"
+      "dev-master": "0.7.x-dev"
     }
   }
 }

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,9 +1,9 @@
 includes:
-	- temp/phpstan/vendor/phpstan/phpstan-deprecation-rules/rules.neon
-	- temp/phpstan/vendor/phpstan/phpstan-nette/extension.neon
-	- temp/phpstan/vendor/phpstan/phpstan-nette/rules.neon
-	- temp/phpstan/vendor/phpstan/phpstan-strict-rules/rules.neon
+	- vendor/phpstan/phpstan-deprecation-rules/rules.neon
+	- vendor/phpstan/phpstan-nette/extension.neon
+	- vendor/phpstan/phpstan-nette/rules.neon
+	- vendor/phpstan/phpstan-strict-rules/rules.neon
 
 parameters:
 	ignoreErrors:
-		- '#Accessing property $arguments on possibly null value of type Nette\DI\Statement|null#'
+		- '#^Parameter \#1 \$function of function call_user_func expects callable\(\): mixed, array\(string\|null, .+\) given.$#'

--- a/ruleset.xml
+++ b/ruleset.xml
@@ -1,18 +1,24 @@
 <?xml version="1.0"?>
 <ruleset name="Contributte">
-    <!-- Contributte Coding Standard -->
-	<rule ref="./vendor/ninjify/coding-standard/contributte.xml"/>
 
-    <!-- Specific rules -->
-    <rule ref="SlevomatCodingStandard.Files.TypeNameMatchesFileName">
-        <properties>
-            <property name="rootNamespaces" type="array" value="
-                src=>Contributte\Console,
-                tests/fixtures=>Tests\Fixtures
-            "/>
-        </properties>
-    </rule>
+	<!-- Contributte Coding Standard -->
+	<rule ref="./vendor/ninjify/coding-standard/contributte.xml">
+		<exclude name="SlevomatCodingStandard.ControlStructures.ControlStructureSpacing"/>
+		<exclude name="SlevomatCodingStandard.ControlStructures.RequireTernaryOperator"/>
+		<exclude name="SlevomatCodingStandard.ControlStructures.EarlyExit"/>
+	</rule>
 
-    <!-- Exclude folders -->
-    <exclude-pattern>/tests/tmp</exclude-pattern>
+	<!-- Specific rules -->
+	<rule ref="SlevomatCodingStandard.Files.TypeNameMatchesFileName">
+		<properties>
+			<property name="rootNamespaces" type="array" value="
+				src=>Contributte\Console,
+				tests/cases=>Tests\Cases,
+				tests/fixtures=>Tests\Fixtures
+			"/>
+		</properties>
+	</rule>
+
+	<!-- Exclude folders -->
+	<exclude-pattern>/tests/tmp</exclude-pattern>
 </ruleset>

--- a/src/CommandLoader/ContainerCommandLoader.php
+++ b/src/CommandLoader/ContainerCommandLoader.php
@@ -4,6 +4,7 @@ namespace Contributte\Console\CommandLoader;
 
 use Contributte\Console\Exception\Runtime\CommandNotFoundException;
 use Nette\DI\Container;
+use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\CommandLoader\CommandLoaderInterface;
 
 class ContainerCommandLoader implements CommandLoaderInterface
@@ -28,7 +29,7 @@ class ContainerCommandLoader implements CommandLoaderInterface
 	 * Loads a command.
 	 *
 	 * @param string $name
-	 * @return object
+	 * @return Command
 	 * @throws CommandNotFoundException
 	 * @phpcsSuppress SlevomatCodingStandard.TypeHints.TypeHintDeclaration.MissingParameterTypeHint
 	 * @phpcsSuppress SlevomatCodingStandard.TypeHints.TypeHintDeclaration.MissingReturnTypeHint

--- a/tests/cases/Unit/Command/Command.HelperSet.phpt
+++ b/tests/cases/Unit/Command/Command.HelperSet.phpt
@@ -14,7 +14,7 @@ use Tester\Assert;
 use Tester\FileMock;
 use Tests\Fixtures\HelperSetCommand;
 
-require_once __DIR__ . '/../../bootstrap.php';
+require_once __DIR__ . '/../../../bootstrap.php';
 
 // Test auto filling helperSet in command
 test(function (): void {

--- a/tests/cases/Unit/CommandLoader/CommandLoader.phpt
+++ b/tests/cases/Unit/CommandLoader/CommandLoader.phpt
@@ -10,7 +10,7 @@ use Nette\DI\Container;
 use Tester\Assert;
 use Tester\Environment;
 
-require_once __DIR__ . '/../../bootstrap.php';
+require_once __DIR__ . '/../../../bootstrap.php';
 
 if (!interface_exists('Symfony\Component\Console\CommandLoader\CommandLoaderInterface', true)) {
 	Environment::skip('CommandLoaderInterface is available from symfony/console 3.4');

--- a/tests/cases/Unit/DI/ConsoleExtension.lazy.phpt
+++ b/tests/cases/Unit/DI/ConsoleExtension.lazy.phpt
@@ -11,15 +11,10 @@ use Nette\DI\Container;
 use Nette\DI\ContainerLoader;
 use Symfony\Component\Console\Command\Command;
 use Tester\Assert;
-use Tester\Environment;
 use Tester\FileMock;
 use Tests\Fixtures\FooCommand;
 
-require_once __DIR__ . '/../../bootstrap.php';
-
-if (!interface_exists('Symfony\Component\Console\CommandLoader\CommandLoaderInterface', true)) {
-	Environment::skip('CommandLoaderInterface is available from symfony/console 3.4');
-}
+require_once __DIR__ . '/../../../bootstrap.php';
 
 // 1 command of type FooCommand lazy-loading
 test(function (): void {

--- a/tests/php-unix.ini
+++ b/tests/php-unix.ini
@@ -1,8 +1,0 @@
-[PHP]
-;extension_dir = "./ext"
-extension=tokenizer.so
-;extension=json.so
-;extension=mcrypt.so
-
-[Zend]
-;zend_extension="./ext/zend_extension"


### PR DESCRIPTION
- Closes #25 
- Require PHP ^7.2
- Test against PHP 7.2-8.0
- Support new yummy nette/schema. Refactor configuration to allow pass any key needed.
- Lazy by default.
- symfony/console >= 4.2.5.

----

```
{
  "require": {
    "contributte/console": "^0.7.0"
  }
}
```