### PR TITLE
Ability to set a custom console Application class

### DIFF
--- a/.docs/README.md
+++ b/.docs/README.md
@@ -31,6 +31,7 @@ console:
     autoExit: true / false
     url: https://contributte.com
     lazy: false
+    applicationClass: Project\Console\Application
 ```
 
 In SAPI (CLI) mode there is no http request and thus no URL address. This is an inconvenience you have to solve by yourself - via the `console.url` option.

--- a/src/DI/ConsoleExtension.php
+++ b/src/DI/ConsoleExtension.php
@@ -63,6 +63,7 @@ class ConsoleExtension extends CompilerExtension
 				Expect::anyOf(Expect::string(), Expect::array(), Expect::type(Statement::class))
 			),
 			'lazy' => Expect::bool(true),
+			'applicationClass' => Expect::string(Application::class),
 		]);
 	}
 
@@ -82,7 +83,7 @@ class ConsoleExtension extends CompilerExtension
 
 		// Register Symfony Console Application
 		$applicationDef = $builder->addDefinition($this->prefix('application'))
-			->setFactory(Application::class);
+			->setFactory($config->applicationClass);
 
 		// Setup console name
 		if ($config->name !== null) {


### PR DESCRIPTION
I don't want to override whole extension only for changing the Application class.

Please, consider merge this. Thank you.