### PR TITLE
Fix setting url to http.request

### DIFF
--- a/src/DI/ConsoleExtension.php
+++ b/src/DI/ConsoleExtension.php
@@ -153,7 +153,9 @@ class ConsoleExtension extends CompilerExtension
 		if ($config->url !== null && $builder->hasDefinition('http.request')) {
 			/** @var ServiceDefinition $httpDef */
 			$httpDef = $builder->getDefinition('http.request');
-			$httpDef->setFactory(Request::class, [new Statement(UrlScript::class, [$config->url])]);
+			if ($httpDef->getFactory() === Request::class) {
+				$httpDef->setFactory(Request::class, [new Statement(UrlScript::class, [$config->url])]);
+			}
 		}
 
 		// Register all commands (if they are not lazy-loaded)

--- a/src/DI/ConsoleExtension.php
+++ b/src/DI/ConsoleExtension.php
@@ -12,8 +12,6 @@ use Nette\DI\Definitions\ServiceDefinition;
 use Nette\DI\Definitions\Statement;
 use Nette\DI\MissingServiceException;
 use Nette\DI\ServiceCreationException;
-use Nette\Http\Request;
-use Nette\Http\UrlScript;
 use Nette\Schema\Expect;
 use Nette\Schema\Schema;
 use Nette\Schema\ValidationException;
@@ -150,12 +148,10 @@ class ConsoleExtension extends CompilerExtension
 		$applicationDef = $builder->getDefinition($this->prefix('application'));
 
 		// Setup URL for CLI
-		if ($config->url !== null && $builder->hasDefinition('http.request')) {
+		if ($config->url !== null && $builder->hasDefinition('http.requestFactory')) {
 			/** @var ServiceDefinition $httpDef */
-			$httpDef = $builder->getDefinition('http.request');
-			if ($httpDef->getFactory() === Request::class) {
-				$httpDef->setFactory(Request::class, [new Statement(UrlScript::class, [$config->url])]);
-			}
+			$httpDef = $builder->getDefinition('http.requestFactory');
+			$httpDef->setFactory(RequestFactory::class, [$config->url]);
 		}
 
 		// Register all commands (if they are not lazy-loaded)

--- a/src/DI/ConsoleExtension.php
+++ b/src/DI/ConsoleExtension.php
@@ -12,6 +12,7 @@ use Nette\DI\Definitions\ServiceDefinition;
 use Nette\DI\Definitions\Statement;
 use Nette\DI\MissingServiceException;
 use Nette\DI\ServiceCreationException;
+use Nette\Http\RequestFactory;
 use Nette\Schema\Expect;
 use Nette\Schema\Schema;
 use Nette\Schema\ValidationException;
@@ -151,7 +152,14 @@ class ConsoleExtension extends CompilerExtension
 		if ($config->url !== null && $builder->hasDefinition('http.requestFactory')) {
 			/** @var ServiceDefinition $httpDef */
 			$httpDef = $builder->getDefinition('http.requestFactory');
-			$httpDef->setFactory(RequestFactory::class, [$config->url]);
+			$factoryEntity = $httpDef->getFactory()->getEntity();
+			if ($factoryEntity === RequestFactory::class) {
+				$httpDef->setFactory(ConsoleRequestFactory::class, [$config->url]);
+			} else {
+				throw new InvalidArgumentException(
+					'Custom http.requestFactory is used, argument console.url should be removed.'
+				);
+			}
 		}
 
 		// Register all commands (if they are not lazy-loaded)

--- a/src/DI/ConsoleRequestFactory.php
+++ b/src/DI/ConsoleRequestFactory.php
@@ -3,9 +3,10 @@
 namespace Contributte\Console\DI;
 
 use Nette\Http\Request;
+use Nette\Http\RequestFactory;
 use Nette\Http\UrlScript;
 
-class RequestFactory extends \Nette\Http\RequestFactory
+class ConsoleRequestFactory extends RequestFactory
 {
 
 	/** @var string */

--- a/src/DI/ConsoleRequestFactory.php
+++ b/src/DI/ConsoleRequestFactory.php
@@ -23,4 +23,10 @@ class ConsoleRequestFactory extends RequestFactory
 		return new Request(new UrlScript($this->url));
 	}
 
+
+	public function createHttpRequest(): Request
+	{
+		return $this->fromGlobals();
+	}
+
 }

--- a/src/DI/RequestFactory.php
+++ b/src/DI/RequestFactory.php
@@ -1,0 +1,25 @@
+<?php declare(strict_types = 1);
+
+namespace Contributte\Console\DI;
+
+use Nette\Http\Request;
+use Nette\Http\UrlScript;
+
+class RequestFactory extends \Nette\Http\RequestFactory
+{
+
+	/** @var string */
+	private $url;
+
+	public function __construct(string $url)
+	{
+		$this->url = $url;
+	}
+
+
+	public function fromGlobals(): Request
+	{
+		return new Request(new UrlScript($this->url));
+	}
+
+}

--- a/tests/fixtures/CustomRequestFactory.php
+++ b/tests/fixtures/CustomRequestFactory.php
@@ -1,0 +1,19 @@
+<?php declare(strict_types = 1);
+
+namespace Tests\Fixtures;
+
+use Nette\Http\Request;
+use Nette\Http\RequestFactory;
+use Nette\Http\UrlScript;
+
+class CustomRequestFactory extends RequestFactory
+{
+
+	public const CUSTOM_URL = 'http://custom/';
+
+	public function fromGlobals(): Request
+	{
+		return new Request(new UrlScript(self::CUSTOM_URL));
+	}
+
+}

--- a/tests/fixtures/CustomRequestFactory.php
+++ b/tests/fixtures/CustomRequestFactory.php
@@ -16,4 +16,9 @@ class CustomRequestFactory extends RequestFactory
 		return new Request(new UrlScript(self::CUSTOM_URL));
 	}
 
+	public function createHttpRequest(): Request
+	{
+		return $this->fromGlobals();
+	}
+
 }


### PR DESCRIPTION
Service `http.request` can be any class implementing interface IRequest. If you have custom IRequest implementation and `console.url` config is set, DI container cache looks like this: 
```php
public function createServiceHttp__request(): Flowgate\FunctionalTests\RequestMock
{
	return new Nette\Http\Request(new Nette\Http\UrlScript('http://localhost'));
}
```
, which causes type error. It should look like this
```php
public function createServiceHttp__request(): Flowgate\FunctionalTests\RequestMock
{
	return new Flowgate\FunctionalTests\RequestMock;
}
```