### PR TITLE
Add console Application to DI container exported types

### DIFF
--- a/src/DI/ConsoleExtension.php
+++ b/src/DI/ConsoleExtension.php
@@ -123,6 +123,9 @@ class ConsoleExtension extends CompilerExtension
 
 			$applicationDef->addSetup('setCommandLoader', ['@' . $this->prefix('commandLoader')]);
 		}
+
+		// Export types
+		$this->compiler->addExportedType(Application::class);
 	}
 
 	/**

--- a/tests/cases/DI/ConsoleExtension.phpt
+++ b/tests/cases/DI/ConsoleExtension.phpt
@@ -11,6 +11,7 @@ use Nette\Bridges\HttpDI\HttpExtension;
 use Nette\DI\Compiler;
 use Nette\DI\Container;
 use Nette\DI\ContainerLoader;
+use Nette\DI\Extensions\DIExtension;
 use Nette\DI\MissingServiceException;
 use Nette\DI\ServiceCreationException;
 use Symfony\Component\Console\Command\Command;
@@ -165,4 +166,24 @@ test(function (): void {
 		', 'neon'));
 		}, [getmypid(), 7]);
 	}, ServiceCreationException::class, 'Command "Tests\Fixtures\NoNameCommand" missing tag "console.command[name]" or variable "$defaultName".');
+});
+
+// Always exported
+test(function (): void {
+	$loader = new ContainerLoader(TEMP_DIR, true);
+	$class = $loader->load(function (Compiler $compiler): void {
+		$compiler->addExtension('console', new ConsoleExtension(true));
+		$compiler->addExtension('di', new DIExtension());
+		$compiler->loadConfig(FileMock::create('
+		di:
+			export:
+				types: null
+		', 'neon'));
+	}, [getmypid(), 8]);
+
+	/** @var Container $container */
+	$container = new $class();
+
+	$application = $container->getByType(Application::class);
+	Assert::type(Application::class, $application);
 });


### PR DESCRIPTION
Hello,
when I turn off type exporting of Nette DI container like this:
```
di:
	export:
		parameters: no
		tags: no
		types:
```
I have to add `Contributte\Console\Application` to the types to get it by type in `bin/console`, while e.g. `Nette\Application\Application` works "out-of-the-box", because it is added to compiler's exported types in `ApplicationExtension`, i.e. it is always exported. 

This PR likewise adds `Contributte\Console\Application` to compiler's exported types, so it works even when other types are not exported.