### PR TITLE
Set catchExceptions to false by default

### DIFF
--- a/.docs/README.md
+++ b/.docs/README.md
@@ -27,7 +27,7 @@ That's all. You don't have to worry about anything else.
 console:
 	name: Acme Project
 	version: '1.0'
-	catchExceptions: true / false
+	catchExceptions: true / false # Keep it false (default), if you want tracy to handle your exceptions
 	autoExit: true / false
 	url: https://example.com
 	lazy: false

--- a/src/DI/ConsoleExtension.php
+++ b/src/DI/ConsoleExtension.php
@@ -48,7 +48,7 @@ class ConsoleExtension extends CompilerExtension
 			'url' => Expect::anyOf(Expect::string(), Expect::null()),
 			'name' => Expect::string(),
 			'version' => Expect::anyOf(Expect::string(), Expect::int(), Expect::float()),
-			'catchExceptions' => Expect::bool(),
+			'catchExceptions' => Expect::bool(false),
 			'autoExit' => Expect::bool(),
 			'helperSet' => Expect::anyOf(Expect::string(), Expect::type(Statement::class)),
 			'helpers' => Expect::arrayOf(
@@ -87,9 +87,7 @@ class ConsoleExtension extends CompilerExtension
 		}
 
 		// Catch or populate exceptions
-		if ($config->catchExceptions !== null) {
-			$applicationDef->addSetup('setCatchExceptions', [$config->catchExceptions]);
-		}
+		$applicationDef->addSetup('setCatchExceptions', [$config->catchExceptions]);
 
 		// Call die() or not
 		if ($config->autoExit !== null) {


### PR DESCRIPTION
Default value for `catchExceptions` is inherited from symfony/console (true), it means that exception will be always caught by symfony/console and displayed as a red text in console and it won't be thrown again, so Tracy can't catch it and it won't be logged anywhere.