### PR TITLE
Fix: fixed support for AsCommand aliases (with tests)

### DIFF
--- a/src/DI/ConsoleExtension.php
+++ b/src/DI/ConsoleExtension.php
@@ -157,6 +157,7 @@ class ConsoleExtension extends CompilerExtension
 				}
 			}
 
+			$aliases = [];
 			// Try to detect command name from Command::getDefaultName()
 			if ($commandName === null) {
 				$commandName = call_user_func([$service->getType(), 'getDefaultName']); // @phpstan-ignore-line
@@ -168,10 +169,19 @@ class ConsoleExtension extends CompilerExtension
 						)
 					);
 				}
+				$aliases = explode('|', $commandName);
+				$commandName = array_shift($aliases);
+				if ($commandName === '') {
+					$commandName = array_shift($aliases);
+				}
 			}
 
 			// Append service to command map
 			$commandMap[$commandName] = $serviceName;
+
+			foreach ($aliases as $alias) {
+				$commandMap[$alias] = $serviceName;
+			}
 		}
 
 		/** @var ServiceDefinition $commandLoaderDef */

--- a/tests/Fixtures/FooAliasCommand.php
+++ b/tests/Fixtures/FooAliasCommand.php
@@ -1,0 +1,23 @@
+<?php declare(strict_types = 1);
+
+namespace Tests\Fixtures;
+
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+#[AsCommand(
+	name: 'app:foo',
+	description: 'Foo command',
+	aliases: ['foo', 'bar']
+)]
+final class FooAliasCommand extends Command
+{
+
+	protected function execute(InputInterface $input, OutputInterface $output): int
+	{
+		return 0;
+	}
+
+}

--- a/tests/Fixtures/FooHiddenCommand.php
+++ b/tests/Fixtures/FooHiddenCommand.php
@@ -1,0 +1,23 @@
+<?php declare(strict_types = 1);
+
+namespace Tests\Fixtures;
+
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+#[AsCommand(
+	name: 'app:foo',
+	description: 'Foo command',
+	hidden: true
+)]
+final class FooHiddenCommand extends Command
+{
+
+	protected function execute(InputInterface $input, OutputInterface $output): int
+	{
+		return 0;
+	}
+
+}


### PR DESCRIPTION
Based on https://github.com/contributte/console/pull/78
Added two tests - one for command with aliases, the second one for hidden commands.
The tests fail when the changes to `src/DI/ConsoleExtension.php` are not applied.