### PR TITLE
Remove phpdbg from coverage target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ tests:
 .PHONY: coverage
 coverage:
 ifdef GITHUB_ACTION
-	vendor/bin/tester -s -p phpdbg --colors 1 -C --coverage coverage.xml --coverage-src src tests/Cases
+	vendor/bin/tester -s -p php --colors 1 -C --coverage coverage.xml --coverage-src src tests/Cases
 else
-	vendor/bin/tester -s -p phpdbg --colors 1 -C --coverage coverage.html --coverage-src src tests/Cases
+	vendor/bin/tester -s -p php --colors 1 -C --coverage coverage.html --coverage-src src tests/Cases
 endif


### PR DESCRIPTION
## Summary

Replace `-p phpdbg` with `-p php` in the `coverage` target so coverage runs use the standard PHP CLI, matching the org-wide cleanup tracked in #73.

## Motivation

`phpdbg` is being removed from Contributte coverage targets. This keeps `contributte/console` aligned with that migration.

## Changes

- switch both `coverage` target variants in `Makefile` from `phpdbg` to `php`

## Testing

- [x] Tests pass locally (`make tests`)
- [ ] Coverage passes locally (`make coverage` currently fails because this environment has no Xdebug, PCOV, or PHPDBG coverage driver)
- [ ] CI passes

What changed:
- updated `Makefile` coverage invocations to use `php`

Why:
- remove the remaining `phpdbg` dependency from this repository's coverage target