### PR TITLE
CI: inherit secrets in coverage workflow

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -14,5 +14,6 @@ jobs:
   coverage:
     name: "Nette Tester"
     uses: contributte/.github/.github/workflows/nette-tester-coverage-v2.yml@master
+    secrets: inherit
     with:
       php: "8.2"


### PR DESCRIPTION
## What changed

- Added `secrets: inherit` to `.github/workflows/coverage.yml` for the reusable coverage workflow call.

## Why

- This completes the issue 74 rollout for this repository so the reusable workflow receives the required secrets context.
- Related: contributte/contributte#74